### PR TITLE
Add button debouncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@
 /nbproject/private/
 /queuelogs/debugtool
 /debug/default/queuelogs/debugtool
+/mcc-manifest-autosave.yml
+/mcc-manifest-generated-success.yml

--- a/DonAlarm_2_MCC.mc3
+++ b/DonAlarm_2_MCC.mc3
@@ -1,4 +1,4 @@
-<config configName="default" projectName="DonAlarm_2_MCC" configVersion="1.1" device="PIC18LF46K40" deviceLibraryClass="com.microchip.mcc.mcu8.Mcu8PeripheralLibrary" coreVersion="5.5.7">
+<config configName="default" projectName="DonAlarm_2_MCC" configVersion="1.1" device="PIC18LF46K40" deviceLibraryClass="com.microchip.mcc.mcu8.Mcu8PeripheralLibrary" coreVersion="5.6.1">
    <usedPackages class="java.util.ArrayList"/>
    <usedClasses class="java.util.TreeMap">
       <entry>
@@ -48,6 +48,10 @@
       <entry>
          <string>System Module</string>
          <string>class com.microchip.mcc.mcu8.systemManager.SystemManager</string>
+      </entry>
+      <entry>
+         <string>TMR0</string>
+         <string>class com.microchip.mcc.mcu8.modules.tmr0_mid0.TMR0</string>
       </entry>
       <entry>
          <string>TMR1</string>
@@ -292,7 +296,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="ADCC" name="dependentModuleKey"/>
-         <value>18</value>
+         <value>19</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="ADCC" name="fvrBufferGainInput"/>
@@ -1472,7 +1476,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="CLKREF" name="dependentModuleKey"/>
-         <value>4</value>
+         <value>5</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="CLKREF" name="intermoduleEnable"/>
@@ -4211,11 +4215,15 @@
          <value>enabled</value>
       </entry>
       <entry>
-         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="Pin Module" name="T1CKIPPS%aux1"/>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="Pin Module" name="T0CKIPPS%aux1"/>
          <value>%DESELECT%</value>
       </entry>
       <entry>
-         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="Pin Module" name="T1GPPS%aux2"/>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="Pin Module" name="T1CKIPPS%aux2"/>
+         <value>%DESELECT%</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="Pin Module" name="T1GPPS%aux3"/>
          <value>%DESELECT%</value>
       </entry>
       <entry>
@@ -10147,6 +10155,322 @@
          <value>OFF</value>
       </entry>
       <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="CallbackFuncRate"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="TMR0_TMRIISRFunction"/>
+         <value>ISR</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="actualPeriod"/>
+         <value>0.001</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="clockFreqKey"/>
+         <value>8000000</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="externalFrequency"/>
+         <value>100000</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="inputMode"/>
+         <value>periodMode</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="maxPeriod"/>
+         <value>0.001024</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="minPeriod"/>
+         <value>0.000004</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="postscaleDivisor"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="prescaleDivisor"/>
+         <value>8</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="prescaledFreq"/>
+         <value>250000</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="requestedPeriod"/>
+         <value>0.001</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="t0ckiPin"/>
+         <value>disabled</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="tickerFactor"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="timerstart"/>
+         <value>enabled</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="tmrMode"/>
+         <value>8-bit</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T016BIT" alias="16-bit"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T016BIT" alias="8-bit"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0EN" alias="disabled"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0EN" alias="enabled"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUT" alias="high"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUT" alias="low"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:1"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:10"/>
+         <value>9</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:11"/>
+         <value>10</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:12"/>
+         <value>11</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:13"/>
+         <value>12</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:14"/>
+         <value>13</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:15"/>
+         <value>14</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:16"/>
+         <value>15</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:2"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:3"/>
+         <value>2</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:4"/>
+         <value>3</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:5"/>
+         <value>4</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:6"/>
+         <value>5</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:7"/>
+         <value>6</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:8"/>
+         <value>7</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS" alias="1:9"/>
+         <value>8</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0ASYNC" alias="not_synchronised"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0ASYNC" alias="synchronised"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:1"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:1024"/>
+         <value>10</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:128"/>
+         <value>7</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:16"/>
+         <value>4</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:16384"/>
+         <value>14</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:2"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:2048"/>
+         <value>11</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:256"/>
+         <value>8</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:32"/>
+         <value>5</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:32768"/>
+         <value>15</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:4"/>
+         <value>2</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:4096"/>
+         <value>12</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:512"/>
+         <value>9</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:64"/>
+         <value>6</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:8"/>
+         <value>3</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS" alias="1:8192"/>
+         <value>13</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="FOSC/4"/>
+         <value>2</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="HFINTOSC"/>
+         <value>3</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="LFINTOSC"/>
+         <value>4</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="SOSC"/>
+         <value>5</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="T0CKI_PIN"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.OptionKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS" alias="T0CKI_nPIN"/>
+         <value>1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="T0CON0"/>
+         <value>128</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="T0CON1"/>
+         <value>67</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="TMR0H"/>
+         <value>249</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="TMR0L"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T016BIT"/>
+         <value>8-bit</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0EN"/>
+         <value>enabled</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUT"/>
+         <value>low</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON0" settingAlias="T0OUTPS"/>
+         <value>1:1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0ASYNC"/>
+         <value>synchronised</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS"/>
+         <value>1:8</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS"/>
+         <value>FOSC/4</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMR0H" settingAlias="TMR0H"/>
+         <value>249</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMR0L" settingAlias="TMR0L"/>
+         <value>0</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMRI" settingAlias="enable"/>
+         <value>enabled</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMRI" settingAlias="flag"/>
+         <value>disabled</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMRI" settingAlias="order"/>
+         <value>-1</value>
+      </entry>
+      <entry>
+         <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMRI" settingAlias="priority"/>
+         <value>1</value>
+      </entry>
+      <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR1" name="CallbackFuncRate"/>
          <value>0</value>
       </entry>
@@ -10547,106 +10871,114 @@
          <value>WDT window violation reset has not occurred</value>
       </entry>
    </tokenMap>
-   <generatedFileHashHistoryMap class="java.util.HashMap">
+   <generatedFileHashHistoryMap class="java.util.TreeMap">
       <entry>
-         <file>mcc_generated_files\interrupt_manager.h</file>
-         <hash>ca3bdd0d4b21685211d243ae9e5a5d77334968a355458c2c22de282cce72854c</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\memory.c</file>
-         <hash>2217f372cdc43bc7a1921582489c64baf203f588e8b11fd8f95bc1c821b343b0</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\spi1.h</file>
-         <hash>db3f1968af3108a0dd5300db178aa54b57dee372ec6cba1bb9576119d1164103</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\clkref.h</file>
-         <hash>08ccc7ee71e903faa88afe73dc8e923d63994b8208ad49cd8ee587191da2f4d5</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\spi1.c</file>
-         <hash>54ebdf99308fd5d25f05e58d49a1705db47d60d0fbea6226562610fbfe2d2a34</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\examples\i2c2_master_example.c</file>
-         <hash>92265b53b2cd82065a169e0f6911115ac756898a6762f4cc0b380ef52548f3b6</hash>
+         <file>main.c</file>
+         <hash>deeae26d9a81791eb3e51a883ec321d5545688677adfbcc4e912cec3aed625cb</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\adcc.c</file>
          <hash>308fbe8a5ada857be8b4f969a22e0fe9e3a1d7ce7f7d5de1e75e6347422e5787</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\fvr.h</file>
-         <hash>184a6664937565d30b03777cbe8444706103d0aaa2da99dbc48e186d9d8903ba</hash>
+         <file>mcc_generated_files\adcc.h</file>
+         <hash>bf4aa8c24f98be5570a289c05955cf97c9d57471681dd268743af5298670a2eb</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\clkref.c</file>
          <hash>b809553f2537a75f465f27533f669f34303248317d9145650f8235b13a008efd</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\fvr.c</file>
-         <hash>6465515a3ed7afbd11464cc8ad045ea4cafed223d2c8b11ebf5a26070dc37ba8</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\mcc.c</file>
-         <hash>29d0567dceec5dab8fc3122261c8cd0e67f5e0825bbb3df45a486a93e3df444f</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\mcc.h</file>
-         <hash>9443fbeef6c3d28c3c4f14082d19b5c2868c8c63fe29de6427c36886fda7562d</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\device_config.h</file>
-         <hash>e436e087e2d313546b949e39658e0831fb1a5909ed4aeed63faf67f5d6b1169d</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\tmr1.h</file>
-         <hash>e302e889dca26b9096859c28232974add08347c935866b59b303677960c8db21</hash>
-      </entry>
-      <entry>
-         <file>main.c</file>
-         <hash>deeae26d9a81791eb3e51a883ec321d5545688677adfbcc4e912cec3aed625cb</hash>
+         <file>mcc_generated_files\clkref.h</file>
+         <hash>08ccc7ee71e903faa88afe73dc8e923d63994b8208ad49cd8ee587191da2f4d5</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\device_config.c</file>
          <hash>a51b8e55b7bb61bdda75bbcc3fc181bca6210f87a71914434d214e3698595fbc</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\adcc.h</file>
-         <hash>bf4aa8c24f98be5570a289c05955cf97c9d57471681dd268743af5298670a2eb</hash>
+         <file>mcc_generated_files\device_config.h</file>
+         <hash>e436e087e2d313546b949e39658e0831fb1a5909ed4aeed63faf67f5d6b1169d</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\pin_manager.h</file>
-         <hash>f0ebe779c40694e9038fdab43ffdbb452956b427a9cd0888cfaed8bda5b3f90f</hash>
-      </entry>
-      <entry>
-         <file>mcc_generated_files\tmr1.c</file>
-         <hash>f8c44474af869e4ffcf36d79b9107e9d1532e629944ce9f5d8793a223ab0e2f6</hash>
+         <file>mcc_generated_files\examples\i2c2_master_example.c</file>
+         <hash>92265b53b2cd82065a169e0f6911115ac756898a6762f4cc0b380ef52548f3b6</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\examples\i2c2_master_example.h</file>
          <hash>01042cb53994c77c5fe39a3f8bea7b1a2169d2c7dc3352a8f3af3b17437b9b56</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\pin_manager.c</file>
-         <hash>351274e84da60992ca60921505b40d0c39cae195f20cdbcbbdf4c9a5581b6459</hash>
+         <file>mcc_generated_files\fvr.c</file>
+         <hash>6465515a3ed7afbd11464cc8ad045ea4cafed223d2c8b11ebf5a26070dc37ba8</hash>
       </entry>
       <entry>
-         <file>mcc_generated_files\i2c2_master.h</file>
-         <hash>42a3fb880081a84ca4e7dad08f229582f7eff827baff9d57cb997a0f887bb3a0</hash>
+         <file>mcc_generated_files\fvr.h</file>
+         <hash>184a6664937565d30b03777cbe8444706103d0aaa2da99dbc48e186d9d8903ba</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\i2c2_master.c</file>
          <hash>e6e95d839e7a1869ae913ae96b75bdfee94f1283487eb775b7c2b7949a679f1b</hash>
       </entry>
       <entry>
+         <file>mcc_generated_files\i2c2_master.h</file>
+         <hash>42a3fb880081a84ca4e7dad08f229582f7eff827baff9d57cb997a0f887bb3a0</hash>
+      </entry>
+      <entry>
          <file>mcc_generated_files\interrupt_manager.c</file>
-         <hash>f4057c62c9752383642aa09ab7a30107e3ebfdddb895f71513a8c83f5d9d9014</hash>
+         <hash>0c05a54d3e1d4c686d9c8dd470dcb820f2a0b00c3d2c66635efcf9ff392cb956</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\interrupt_manager.h</file>
+         <hash>ca3bdd0d4b21685211d243ae9e5a5d77334968a355458c2c22de282cce72854c</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\mcc.c</file>
+         <hash>bc331ea4423209ee05a8a1a0b50ab975f8c26547c8481e684bc3adb7b823b7f0</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\mcc.h</file>
+         <hash>209d6f1a6335f453fc63bec71ade9c38dbce536f6fba2170b27d04c298a6f3ee</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\memory.c</file>
+         <hash>2217f372cdc43bc7a1921582489c64baf203f588e8b11fd8f95bc1c821b343b0</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\memory.h</file>
          <hash>c2c9a02eca17ab83f0f9a0c72531a299fe1140c745adc1da16271d3655cb271b</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\pin_manager.c</file>
+         <hash>351274e84da60992ca60921505b40d0c39cae195f20cdbcbbdf4c9a5581b6459</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\pin_manager.h</file>
+         <hash>f0ebe779c40694e9038fdab43ffdbb452956b427a9cd0888cfaed8bda5b3f90f</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\spi1.c</file>
+         <hash>54ebdf99308fd5d25f05e58d49a1705db47d60d0fbea6226562610fbfe2d2a34</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\spi1.h</file>
+         <hash>db3f1968af3108a0dd5300db178aa54b57dee372ec6cba1bb9576119d1164103</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\tmr0.c</file>
+         <hash>5414b98a2c56db06916af50f553f00e64e37f8a0f06cbbbd488d2aec6f8ab1c1</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\tmr0.h</file>
+         <hash>a2e8ed918e534d83a6ecd7f07d5b29d75b4343d52a327b675082fe13dcf9b186</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\tmr1.c</file>
+         <hash>f8c44474af869e4ffcf36d79b9107e9d1532e629944ce9f5d8793a223ab0e2f6</hash>
+      </entry>
+      <entry>
+         <file>mcc_generated_files\tmr1.h</file>
+         <hash>e302e889dca26b9096859c28232974add08347c935866b59b303677960c8db21</hash>
       </entry>
    </generatedFileHashHistoryMap>
 </config>

--- a/DonAlarm_2_MCC.mc3
+++ b/DonAlarm_2_MCC.mc3
@@ -10164,7 +10164,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="actualPeriod"/>
-         <value>0.001</value>
+         <value>0.004992</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="clockFreqKey"/>
@@ -10180,11 +10180,11 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="maxPeriod"/>
-         <value>0.001024</value>
+         <value>0.008192</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="minPeriod"/>
-         <value>0.000004</value>
+         <value>0.000032</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="postscaleDivisor"/>
@@ -10192,15 +10192,15 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="prescaleDivisor"/>
-         <value>8</value>
+         <value>64</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="prescaledFreq"/>
-         <value>250000</value>
+         <value>31250</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="requestedPeriod"/>
-         <value>0.001</value>
+         <value>0.005</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.CustomKey" moduleName="TMR0" name="t0ckiPin"/>
@@ -10408,11 +10408,11 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="T0CON1"/>
-         <value>67</value>
+         <value>70</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="TMR0H"/>
-         <value>249</value>
+         <value>155</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.RegisterKey" moduleName="TMR0" registerAlias="TMR0L"/>
@@ -10440,7 +10440,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CKPS"/>
-         <value>1:8</value>
+         <value>1:64</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="T0CON1" settingAlias="T0CS"/>
@@ -10448,7 +10448,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMR0H" settingAlias="TMR0H"/>
-         <value>249</value>
+         <value>155</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="TMR0" registerAlias="TMR0L" settingAlias="TMR0L"/>
@@ -10966,7 +10966,7 @@
       </entry>
       <entry>
          <file>mcc_generated_files\tmr0.c</file>
-         <hash>5414b98a2c56db06916af50f553f00e64e37f8a0f06cbbbd488d2aec6f8ab1c1</hash>
+         <hash>fd856d27cdf8052678e182aefb59ce3897d9ddbee55e553fec59aae526fe419b</hash>
       </entry>
       <entry>
          <file>mcc_generated_files\tmr0.h</file>

--- a/main.h
+++ b/main.h
@@ -197,13 +197,18 @@ struct MSTATE {
     uint8_t updateDisplay;
     uint8_t buttonPressed;
     uint8_t pastAlarm;
+    uint8_t portBDebouncedState;    // debounced state
+    uint8_t portBStateLast;         // last state
+    uint8_t debouncedStateLast;
 }mstate;
 
+#define PORTB_IOC_MASK (0b00111000)  // RB3 (BTN_UP), RB4 (BTN_ENTER), RB5 (BTN_DOWN)
 
 void Initialize(void);
 void GetAnalog(void);
 void GetBattVolts(void);
 uint16_t GetRefAnalog(void);
+void ScanPB(void);
 void HandlePB(void);
 void UpdateDisplay(void);
 void SaveEESetup(void);

--- a/main.h
+++ b/main.h
@@ -45,7 +45,7 @@
 #include <xc.h> // include processor files - each processor file is guarded.  
 #include "mcc_generated_files/mcc.h"
 
-const char FIRMWARE_VERSION_STRING[] = "v1.0.1";   // NHAN: show firmware version on device power on
+const char FIRMWARE_VERSION_STRING[] = "v1.0.2";   // NHAN: show firmware version on device power on
 
 #define DAQ_SCALE   0.002       //10bits equals 2.048v (vref) and DAQ_SCALE = (2.048/1025) = 0.002 volts per count
 #define BAT_SCALE   0.004       //Bat volts is 2x analog input of 500cnts/v -> cnts*0.004=bat volts

--- a/mcc_generated_files/interrupt_manager.c
+++ b/mcc_generated_files/interrupt_manager.c
@@ -58,7 +58,11 @@ void  INTERRUPT_Initialize (void)
 void __interrupt() INTERRUPT_InterruptManager (void)
 {
     // interrupt handler
-    if(PIE0bits.IOCIE == 1 && PIR0bits.IOCIF == 1)
+    if(PIE0bits.TMR0IE == 1 && PIR0bits.TMR0IF == 1)
+    {
+        TMR0_ISR();
+    }
+    else if(PIE0bits.IOCIE == 1 && PIR0bits.IOCIF == 1)
     {
         PIN_MANAGER_IOC();
     }

--- a/mcc_generated_files/mcc.c
+++ b/mcc_generated_files/mcc.c
@@ -59,6 +59,8 @@ void SYSTEM_Initialize(void)
     FVR_Initialize();
     ADCC_Initialize();
     TMR1_Initialize();
+    TMR0_Initialize();
+//    CLKREF_Initialize();
 }
 
 void OSCILLATOR_Initialize(void)

--- a/mcc_generated_files/mcc.h
+++ b/mcc_generated_files/mcc.h
@@ -56,6 +56,7 @@
 #include "spi1.h"
 #include "i2c2_master.h"
 #include "tmr1.h"
+#include "tmr0.h"
 #include "adcc.h"
 #include "fvr.h"
 #include "memory.h"

--- a/mcc_generated_files/pin_manager.h
+++ b/mcc_generated_files/pin_manager.h
@@ -1048,6 +1048,7 @@ extern void (*IOCBF5_InterruptHandler)(void);
 */
 void IOCBF5_DefaultInterruptHandler(void);
 
+void IOC_InterruptHandler(void);
 
 
 #endif // PIN_MANAGER_H

--- a/mcc_generated_files/tmr0.c
+++ b/mcc_generated_files/tmr0.c
@@ -1,0 +1,175 @@
+/**
+  TMR0 Generated Driver File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    tmr0.c
+
+  @Summary
+    This is the generated driver implementation file for the TMR0 driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This source file provides APIs for TMR0.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.81.8
+        Device            :  PIC18LF46K40
+        Driver Version    :  3.10
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 2.36 and above
+        MPLAB 	          :  MPLAB X 6.00
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+/**
+  Section: Included Files
+*/
+
+#include <xc.h>
+#include "tmr0.h"
+#include "../main.h"
+
+/**
+  Section: TMR0 APIs
+*/
+
+void (*TMR0_InterruptHandler)(void);
+
+void TMR0_Initialize(void)
+{
+    // Set TMR0 to the options selected in the User Interface
+
+    // T0CS FOSC/4; T0CKPS 1:8; T0ASYNC synchronised; 
+    T0CON1 = 0x43;
+
+    // TMR0H 249; 
+    TMR0H = 0xF9;
+
+    // TMR0L 0; 
+    TMR0L = 0x00;
+
+    // Clear Interrupt flag before enabling the interrupt
+    PIR0bits.TMR0IF = 0;
+
+    // Enable TMR0 interrupt.
+    PIE0bits.TMR0IE = 1;
+
+    // Set Default Interrupt Handler
+    TMR0_SetInterruptHandler(TMR0_DefaultInterruptHandler);
+
+    // T0OUTPS 1:1; T0EN enabled; T016BIT 8-bit; 
+    T0CON0 = 0x80;
+}
+
+void TMR0_StartTimer(void)
+{
+    // Start the Timer by writing to TMR0ON bit
+    T0CON0bits.T0EN = 1;
+}
+
+void TMR0_StopTimer(void)
+{
+    // Stop the Timer by writing to TMR0ON bit
+    T0CON0bits.T0EN = 0;
+}
+
+uint8_t TMR0_ReadTimer(void)
+{
+    uint8_t readVal;
+
+    // read Timer0, low register only
+    readVal = TMR0L;
+
+    return readVal;
+}
+
+void TMR0_WriteTimer(uint8_t timerVal)
+{
+    // Write to Timer0 registers, low register only
+    TMR0L = timerVal;
+ }
+
+void TMR0_Reload(uint8_t periodVal)
+{
+   // Write to Timer0 registers, high register only
+   TMR0H = periodVal;
+}
+
+void TMR0_ISR(void)
+{
+    // clear the TMR0 interrupt flag
+    PIR0bits.TMR0IF = 0;
+    if(TMR0_InterruptHandler)
+    {
+        TMR0_InterruptHandler();
+    }
+
+    // add your TMR0 interrupt custom code
+}
+
+
+void TMR0_SetInterruptHandler(void (* InterruptHandler)(void)){
+    TMR0_InterruptHandler = InterruptHandler;
+}
+
+void TMR0_DefaultInterruptHandler(void){
+    // add your TMR0 interrupt custom code
+    // or set custom function using TMR0_SetInterruptHandler()
+    
+//    if (!SWDebounce())
+//    {
+//        // We're stable, disable this timer and go back to IOC mode
+//        // Disable Timer0
+//        PIR0bits.TMR0IF = 0;    // clear Timer0 interrupt flag
+//        PIE0bits.TMR0IE = 0;    // Disable Timer0 interrupt
+//        T0CON0bits.T0EN = 0;    // Stop Timer0
+////        
+////        // Clean up and enable IOC again
+//        PIR0bits.IOCIF = 0; // Clear IOC flag;
+//        PIE0bits.IOCIE = 1; // Enable IOC interrupts.
+//    }
+    
+    SWDebounce();
+    PIR0bits.TMR0IF = 0;    // clear Timer0 interrupt flag
+}
+
+bool SWDebounce(void)
+{
+    uint8_t portUnstableMask;
+    uint8_t portStateNow = PORTB;
+    
+    // Debounce the entire PORTB
+    // This only works if all switches are on PORTB
+    portUnstableMask = portStateNow ^ mstate.portBStateLast; // bit set to 1 means port bit is unstable, i.e. changed since last time
+    mstate.portBStateLast = portStateNow;
+    mstate.portBDebouncedState = (mstate.portBDebouncedState & portUnstableMask) | (portStateNow & ~portUnstableMask); // maintain old state | merge stable state
+    
+    return (portUnstableMask & PORTB_IOC_MASK) != 0;    // If any of the monitored port bits have changed, return true
+}
+
+/**
+  End of File
+*/

--- a/mcc_generated_files/tmr0.c
+++ b/mcc_generated_files/tmr0.c
@@ -62,11 +62,11 @@ void TMR0_Initialize(void)
 {
     // Set TMR0 to the options selected in the User Interface
 
-    // T0CS FOSC/4; T0CKPS 1:8; T0ASYNC synchronised; 
-    T0CON1 = 0x43;
+    // T0CS FOSC/4; T0CKPS 1:64; T0ASYNC synchronised; 
+    T0CON1 = 0x46;
 
-    // TMR0H 249; 
-    TMR0H = 0xF9;
+    // TMR0H 155; 
+    TMR0H = 0x9B;
 
     // TMR0L 0; 
     TMR0L = 0x00;
@@ -74,7 +74,7 @@ void TMR0_Initialize(void)
     // Clear Interrupt flag before enabling the interrupt
     PIR0bits.TMR0IF = 0;
 
-    // Enable TMR0 interrupt.
+    // Enabling TMR0 interrupt.
     PIE0bits.TMR0IE = 1;
 
     // Set Default Interrupt Handler

--- a/mcc_generated_files/tmr0.h
+++ b/mcc_generated_files/tmr0.h
@@ -1,0 +1,359 @@
+/**
+  TMR0 Generated Driver API Header File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    tmr0.h
+
+  @Summary
+    This is the generated header file for the TMR0 driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This header file provides APIs for TMR0.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.81.8
+        Device            :  PIC18LF46K40
+        Driver Version    :  3.10
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 2.36 and above
+        MPLAB 	          :  MPLAB X 6.00
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+#ifndef TMR0_H
+#define TMR0_H
+
+/**
+  Section: Included Files
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+
+
+
+/**
+  Section: TMR0 APIs
+*/
+
+/**
+  @Summary
+    Initializes the TMR0.
+
+  @Description
+    This function initializes the TMR0 Registers.
+    This function must be called before any other TMR0 function is called.
+
+  @Preconditions
+    None
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Comment
+   
+   
+  @Example
+    <code>
+    main()
+    {
+        // Initialize TMR0 module
+        TMR0_Initialize();
+
+        // Do something else...
+    }
+    </code>
+*/
+void TMR0_Initialize(void);
+
+/**
+  @Summary
+    This function starts the TMR0.
+
+  @Description
+    This function starts the TMR0 operation.
+    This function must be called after the initialization of TMR0.
+
+  @Preconditions
+    Initialize  the TMR0 before calling this function.
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Example
+    <code>
+    // Initialize TMR0 module
+
+    // Start TMR0
+    TMR0_StartTimer();
+
+    // Do something else...
+    </code>
+*/
+void TMR0_StartTimer(void);
+
+/**
+  @Summary
+    This function stops the TMR0.
+
+  @Description
+    This function stops the TMR0 operation.
+    This function must be called after the start of TMR0.
+
+  @Preconditions
+    Initialize  the TMR0 before calling this function.
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Example
+    <code>
+    // Initialize TMR0 module
+
+    // Start TMR0
+    TMR0_StartTimer();
+
+    // Do something else...
+
+    // Stop TMR0;
+    TMR0_StopTimer();
+    </code>
+*/
+void TMR0_StopTimer(void);
+
+/**
+  @Summary
+    Reads the 8 bits TMR0 register value.
+
+  @Description
+    This function reads the 8 bits TMR0 register value and return it.
+
+  @Preconditions
+    Initialize  the TMR0 before calling this function.
+
+  @Param
+    None
+
+  @Returns
+    This function returns the 8 bits value of TMR0 register.
+
+  @Example
+    <code>
+    // Initialize TMR0 module
+
+    // Start TMR0
+    TMR0_StartTimer();
+
+    // Read the current value of TMR0
+    if(0 == TMR0_ReadTimer())
+    {
+        // Do something else...
+
+        // Stop TMR0;
+        TMR0_StopTimer();
+    }
+    </code>
+*/
+uint8_t TMR0_ReadTimer(void);
+
+/**
+  @Summary
+    Writes the 8 bits value to TMR0 register.
+
+  @Description
+    This function writes the 8 bits value to TMR0 register.
+    This function must be called after the initialization of TMR0.
+
+  @Preconditions
+    Initialize  the TMR0 before calling this function.
+
+  @Param
+    timerVal - Value to write into TMR0 register.
+
+  @Returns
+    None
+
+  @Example
+    <code>
+    #define PERIOD 0x80
+    #define ZERO   0x00
+
+    while(1)
+    {
+        // Read the TMR0 register
+        if(ZERO == TMR0_ReadTimer())
+        {
+            // Do something else...
+
+            // Write the TMR0 register
+            TMR0_WriteTimer(PERIOD);
+        }
+
+        // Do something else...
+    }
+    </code>
+*/
+void TMR0_WriteTimer(uint8_t timerVal);
+
+/**
+  @Summary
+    Load value to Period Register.
+
+  @Description
+    This function writes the value to TMR0H register.
+    This function must be called after the initialization of TMR0.
+
+  @Preconditions
+    Initialize  the TMR0 before calling this function.
+
+  @Param
+    periodVal - Value to load into TMR0 register.
+
+  @Returns
+    None
+
+
+  @Example
+    <code>
+    while(1)
+    {
+        if(TMR0IF)
+        {
+            // Do something else...
+
+            // clear the TMR0 interrupt flag
+            TMR0IF = 0;
+
+            // Change the period value of TMR0
+            TMR0_Reload(0x80);
+        }
+    }
+    </code>
+*/
+void TMR0_Reload(uint8_t periodVal);
+
+
+/**
+  @Summary
+    Timer Interrupt Service Routine
+
+  @Description
+    Timer Interrupt Service Routine is called by the Interrupt Manager.
+
+  @Preconditions
+    Initialize  the TMR0 module with interrupt before calling this isr.
+
+  @Param
+    None
+
+  @Returns
+    None
+ */
+void TMR0_ISR(void);
+
+
+/**
+  @Summary
+    Set Timer Interrupt Handler
+
+  @Description
+    This sets the function to be called during the ISR
+
+  @Preconditions
+    Initialize  the TMR0 module with interrupt before calling this.
+
+  @Param
+    Address of function to be set
+
+  @Returns
+    None
+*/
+ void TMR0_SetInterruptHandler(void (* InterruptHandler)(void));
+
+/**
+  @Summary
+    Timer Interrupt Handler
+
+  @Description
+    This is a function pointer to the function that will be called during the ISR
+
+  @Preconditions
+    Initialize  the TMR0 module with interrupt before calling this isr.
+
+  @Param
+    None
+
+  @Returns
+    None
+*/
+extern void (*TMR0_InterruptHandler)(void);
+
+/**
+  @Summary
+    Default Timer Interrupt Handler
+
+  @Description
+    This is the default Interrupt Handler function
+
+  @Preconditions
+    Initialize  the TMR0 module with interrupt before calling this isr.
+
+  @Param
+    None
+
+  @Returns
+    None
+*/
+void TMR0_DefaultInterruptHandler(void);
+
+bool SWDebounce(void);
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    }
+
+#endif
+
+#endif // TMR0_H
+/**
+ End of File
+*/

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -326,6 +326,8 @@
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
         <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmerToGoFilePath"
+                  value="D:/Nhan/DonAlarm/2.1/DA2-firmware/debug/default/[Nhan] DonAlarm_2_Dual_MCC_ptg"/>
         <property key="programmerToGoImageName" value="[Nhan] DonAlarm_2_Dual_MCC_ptg"/>
         <property key="programmertogo.imagename" value=""/>
         <property key="programoptions.donoteraseauxmem" value="false"/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -21,6 +21,7 @@
         <itemPath>mcc_generated_files/adcc.h</itemPath>
         <itemPath>mcc_generated_files/fvr.h</itemPath>
         <itemPath>mcc_generated_files/clkref.h</itemPath>
+        <itemPath>mcc_generated_files/tmr0.h</itemPath>
       </logicalFolder>
       <itemPath>main.h</itemPath>
       <itemPath>delays.h</itemPath>
@@ -54,6 +55,7 @@
         <itemPath>mcc_generated_files/spi1.c</itemPath>
         <itemPath>mcc_generated_files/fvr.c</itemPath>
         <itemPath>mcc_generated_files/clkref.c</itemPath>
+        <itemPath>mcc_generated_files/tmr0.c</itemPath>
       </logicalFolder>
       <itemPath>main.c</itemPath>
       <itemPath>delays.c</itemPath>
@@ -440,6 +442,8 @@
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
         <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmerToGoFilePath"
+                  value="D:/Nhan/DonAlarm/2.1/DA2-firmware/debug/default/[Nhan] DonAlarm_2_Dual_MCC_ptg"/>
         <property key="programmerToGoImageName" value="[Nhan] DonAlarm_2_Dual_MCC_ptg"/>
         <property key="programoptions.donoteraseauxmem" value="false"/>
         <property key="programoptions.eraseb4program" value="true"/>


### PR DESCRIPTION
Previously, each button press is sometimes registered as multiple presses.
This is because original program only use IOC to detect button press, and button debouncing is not handled at all.

This PR uses Timer0 to periodically (i.e. 5ms) scan buttons states and return the stable states in `mstate` struct variable.
A new function `ScanPB` is called in each super loop to get these stable states, and subsequent actions will use these stable states.