### PR TITLE
increase alarm instruction time

### DIFF
--- a/main.c
+++ b/main.c
@@ -715,9 +715,9 @@ void UpdateDisplay(void) {
             }
 
             if (!mstate.alarmHigh && !mstate.alarmLow) alternate = 0;
-            if (alternate > 5) alternate = 0;
+            if (alternate > 10) alternate = 0;
 
-            if (alternate < 3) {
+            if (alternate < 5) {
                 // NHAN: increase current pressure font size
                 sprintf(outstring, "%3d", analog.pressure);
                 WriteLargeString(outstring, 1, 1);

--- a/main.h
+++ b/main.h
@@ -45,7 +45,7 @@
 #include <xc.h> // include processor files - each processor file is guarded.  
 #include "mcc_generated_files/mcc.h"
 
-const char FIRMWARE_VERSION_STRING[] = "v1.2.2";   // NHAN: show firmware version on device power on
+const char FIRMWARE_VERSION_STRING[] = "v1.2.3";   // NHAN: show firmware version on device power on
 
 #define DAQ_SCALE   0.002       //10bits equals 2.048v (vref) and DAQ_SCALE = (2.048/1025) = 0.002 volts per count
 #define BAT_SCALE   0.004       //Bat volts is 2x analog input of 500cnts/v -> cnts*0.004=bat volts


### PR DESCRIPTION
Increase alarm instruction time from appro. 3s to appro. 6s.
This allows enough time to read the screens during alarm event.