### PR TITLE
Fix sporadic black lines

### DIFF
--- a/main.c
+++ b/main.c
@@ -1396,7 +1396,7 @@ void secondTimer(void) {
 
         if (mstate.alarmLongSilence) longSleepCount += 4;
     } else {
-        displayCount++; // TODO: after HP > display off, we should not increment this anymore
+        displayCount++;
         displayAlarmCount++;
         if (BTN_DOWN_GetValue() && BTN_UP_GetValue()) dualPressButton++;
         else dualPressButton = 0;

--- a/main.h
+++ b/main.h
@@ -45,7 +45,7 @@
 #include <xc.h> // include processor files - each processor file is guarded.  
 #include "mcc_generated_files/mcc.h"
 
-const char FIRMWARE_VERSION_STRING[] = "v1.3.2";   // NHAN: show firmware version on device power on
+const char FIRMWARE_VERSION_STRING[] = "v1.3.3";   // NHAN: show firmware version on device power on
 
 #define DAQ_SCALE   0.002       //10bits equals 2.048v (vref) and DAQ_SCALE = (2.048/1025) = 0.002 volts per count
 #define BAT_SCALE   0.004       //Bat volts is 2x analog input of 500cnts/v -> cnts*0.004=bat volts
@@ -69,7 +69,7 @@ const char FIRMWARE_VERSION_STRING[] = "v1.3.2";   // NHAN: show firmware versio
 #define CLEARLONGSILENT     600          //Alarm sound back on after 10 minutes
 #else
 #define DISPLAYTIMEOUT      60          // Display off after 1 minute of inactivity
-#define ALARMDISPTIMEOUT    60          // Leave display on for 1 minute after an alarm is triggered        
+#define ALARMDISPTIMEOUT    60          // Leave display on for 1 minute after an alarm is triggered    
 #define CLEARSHORTSILENT    30          // Alarm sound back on after this number of seconds
 #define CLEARLONGSILENT     43200       // Alarm sound back on after 12 hours
 #define ALARM_ACTIVATE_TIMEOUT  3       // pressure has to be out of limits for this amount of seconds to activate


### PR DESCRIPTION
See Bug ID 41.

This is due to LCD display power.

Inside ADC function, when 5V is enabled, original program use a delay of 200ms before ADC conversion. This leaves enough time for the LCD power to rise and show random lines.

I reduce this delay from 200ms to 5ms.
Why 5ms? According to R1202 datasheet, the soft start time is typically 2ms after EN pin is set High. Therefore, 5ms should be more than enough.

By reducing delay time in ADC function, we also reduce the active time of the device, therefore reducing average current consumption.